### PR TITLE
Fix incompatibility with "animated items" mod

### DIFF
--- a/metadata.xml
+++ b/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-    <name>Regret Pedestals</name>
+    <name>'Regret Pedestals</name>
     <directory>regret pedestals</directory>
     <id>2766379837</id>
     <description></description>


### PR DESCRIPTION
By adding a comma before the mod name, TBoI loads this mod before "animated items", making them work both together. (before this change only "animated items" would work)
Edit: I want to add that other mods make use of this fix, like "[Enhanced Boss Bars](https://github.com/wofsauge/Enhanced-Boss-Bars/blob/main/metadata.xml#L3)"